### PR TITLE
Remove Android activity params for new react-native link

### DIFF
--- a/Example/android/app/src/main/java/com/example/MainActivity.java
+++ b/Example/android/app/src/main/java/com/example/MainActivity.java
@@ -38,7 +38,7 @@ public class MainActivity extends ReactActivity {
         return Arrays.<ReactPackage>asList(
             new MainReactPackage(),
             new VectorIconsPackage(),
-            new RCTIJKPlayerPackage(this)
+            new RCTIJKPlayerPackage()
         );
     }
 }

--- a/android/src/main/java/me/yiii/RCTIJKPlayer/RCTIJKPlayerPackage.java
+++ b/android/src/main/java/me/yiii/RCTIJKPlayer/RCTIJKPlayerPackage.java
@@ -1,6 +1,5 @@
 package me.yiii.RCTIJKPlayer;
 
-import android.app.Activity;
 import android.util.Log;
 
 import com.facebook.react.ReactPackage;
@@ -13,10 +12,8 @@ import java.util.Collections;
 import java.util.List;
 
 public class RCTIJKPlayerPackage implements ReactPackage {
-    private Activity activity = null;
     private static final String TAG = "RCTIJKPlayerPackage";
-    public RCTIJKPlayerPackage(Activity activity){
-        this.activity = activity;
+    public RCTIJKPlayerPackage(){
     }
 
     @Override
@@ -32,7 +29,7 @@ public class RCTIJKPlayerPackage implements ReactPackage {
     @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactApplicationContext) {
         //noinspection ArraysAsListWithZeroOrOneArgument
-        return Collections.<ViewManager>singletonList(new RCTIJKPlayerViewManager(activity));
+        return Collections.<ViewManager>singletonList(new RCTIJKPlayerViewManager());
     }
 
 }

--- a/android/src/main/java/me/yiii/RCTIJKPlayer/RCTIJKPlayerView.java
+++ b/android/src/main/java/me/yiii/RCTIJKPlayer/RCTIJKPlayerView.java
@@ -4,7 +4,6 @@
 
 package me.yiii.RCTIJKPlayer;
 
-import android.app.Activity;
 import android.content.Context;
 import android.os.Handler;
 import android.os.Message;
@@ -29,7 +28,6 @@ public class RCTIJKPlayerView extends FrameLayout {
     private static final String TAG = "RCTIJKPlayerView";
     private final Context _context;
     private SurfaceView mPreviewView;
-    private Activity activity = null;
     private FrameLayout framelayout;
     private IjkVideoView mIJKPlayerView;
 
@@ -37,10 +35,9 @@ public class RCTIJKPlayerView extends FrameLayout {
         return this.mIJKPlayerView;
     }
 
-    public RCTIJKPlayerView(Context context, Activity activity) {
+    public RCTIJKPlayerView(Context context) {
         super(context);
         this._context = context;
-        this.activity = activity;
         Log.e(TAG, "*******constructor start");
         // framelayout = new FrameLayout(context);
 

--- a/android/src/main/java/me/yiii/RCTIJKPlayer/RCTIJKPlayerViewManager.java
+++ b/android/src/main/java/me/yiii/RCTIJKPlayer/RCTIJKPlayerViewManager.java
@@ -1,17 +1,12 @@
 package me.yiii.RCTIJKPlayer;
 
-import android.app.Activity;
-
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.ViewGroupManager;
 
 public class RCTIJKPlayerViewManager extends ViewGroupManager<RCTIJKPlayerView> {
     private static final String REACT_CLASS = "RCTIJKPlayer";
 
-    private Activity activity = null;
-
-    public RCTIJKPlayerViewManager(Activity activity){
-        this.activity = activity;
+    public RCTIJKPlayerViewManager() {
     }
 
     @Override
@@ -21,7 +16,7 @@ public class RCTIJKPlayerViewManager extends ViewGroupManager<RCTIJKPlayerView> 
 
     @Override
     public RCTIJKPlayerView createViewInstance(ThemedReactContext context) {
-        return new RCTIJKPlayerView(context, this.activity);
+        return new RCTIJKPlayerView(context);
     }
 
 }


### PR DESCRIPTION
Currently, registering a module provided in the `getPackages` method of the `MainApplication.java` file, which we can't get the activity instance. On the other hand, we don't need to know the activity instance in this module.

Reference:
[register-the-module](https://facebook.github.io/react-native/docs/native-modules-android.html#register-the-module)